### PR TITLE
feat: publish blog to AT Protocol via standard.site

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,10 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Job-level so the publish step's `if` guard can read it (step-level env is
+    # not reliably available in that step's own `if`).
+    env:
+      BSKY_APP_PASSWORD: ${{ secrets.BSKY_APP_PASSWORD }}
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v4
@@ -21,6 +25,13 @@ jobs:
         uses: withastro/action@v3
         with:
           node-version: 22
+      # withastro/action leaves the built ./dist in the workspace; publish the
+      # standard.site (https://standard.site) records to the byk.im PDS from it.
+      # Skips when the secret is unset; a transient PDS outage never fails deploy.
+      - name: Publish standard.site records to the byk.im PDS
+        if: ${{ env.BSKY_APP_PASSWORD != '' }}
+        continue-on-error: true
+        run: node scripts/publish-standard-site.mjs
 
   deploy:
     needs: build

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "publish:standard-site": "node scripts/publish-standard-site.mjs"
   },
   "dependencies": {
     "@astrojs/mdx": "^5.0.3",

--- a/public/.well-known/site.standard.publication
+++ b/public/.well-known/site.standard.publication
@@ -1,0 +1,1 @@
+at://did:plc:kl3s4yablm3fgnxfkn47uy5r/site.standard.publication/self

--- a/scripts/publish-standard-site.mjs
+++ b/scripts/publish-standard-site.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+/**
+ * Publish byk.im's standard.site records (https://standard.site) to the
+ * `@byk.im` Bluesky PDS over AT Protocol.
+ *
+ * Records are read from the build manifest (dist/standard-site.json), so build
+ * the site first:
+ *
+ *   pnpm build
+ *   BSKY_APP_PASSWORD='xxxx-xxxx-xxxx-xxxx' pnpm publish:standard-site
+ *
+ * Auth uses a Bluesky app password (create one at
+ * https://bsky.app/settings/app-passwords). It is read from BSKY_APP_PASSWORD
+ * and never logged. BSKY_HANDLE defaults to "byk.im".
+ *
+ * Idempotent: records use deterministic rkeys (publication "self", documents =
+ * post slug) written with putRecord, so re-running updates them in place rather
+ * than creating duplicates. After upserting the current set, it prunes document
+ * records that no longer have a matching post (deleted posts or renamed slugs)
+ * so the PDS stays in sync with the published blog.
+ */
+
+import { readFile } from "node:fs/promises";
+import { argv } from "node:process";
+import { fileURLToPath } from "node:url";
+
+const HANDLE = process.env.BSKY_HANDLE ?? "byk.im";
+const PASSWORD = process.env.BSKY_APP_PASSWORD;
+const MANIFEST_URL = new URL("../dist/standard-site.json", import.meta.url);
+const WELL_KNOWN_URL = new URL(
+  "../public/.well-known/site.standard.publication",
+  import.meta.url,
+);
+
+function fail(message) {
+  console.error(`✗ ${message}`);
+  process.exit(1);
+}
+
+async function xrpcGet(baseUrl, nsid, query) {
+  const url = new URL(`/xrpc/${nsid}`, baseUrl);
+  for (const [key, value] of Object.entries(query ?? {})) {
+    url.searchParams.set(key, value);
+  }
+  const res = await fetch(url);
+  if (!res.ok) fail(`${nsid} -> ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+async function xrpcPost(baseUrl, nsid, body, token) {
+  const res = await fetch(new URL(`/xrpc/${nsid}`, baseUrl), {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) fail(`${nsid} -> ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+async function resolvePds(did) {
+  const res = await fetch(`https://plc.directory/${did}`);
+  if (!res.ok) fail(`could not resolve DID document for ${did}: ${res.status}`);
+  const doc = await res.json();
+  const pds = (doc.service ?? []).find(
+    (s) => s.type === "AtprotoPersonalDataServer",
+  )?.serviceEndpoint;
+  if (!pds) fail(`no PDS endpoint in DID document for ${did}`);
+  return pds;
+}
+
+async function listAllRecords(pds, repo, collection) {
+  const records = [];
+  let cursor;
+  do {
+    const query = { repo, collection, limit: "100" };
+    if (cursor) query.cursor = cursor;
+    const page = await xrpcGet(pds, "com.atproto.repo.listRecords", query);
+    const batch = page.records ?? [];
+    records.push(...batch);
+    // Stop when a page returns nothing, even if the PDS still hands back a
+    // cursor, so an always-present cursor can never spin forever.
+    cursor = batch.length > 0 ? page.cursor : undefined;
+  } while (cursor);
+  return records;
+}
+
+/**
+ * Pure diff: given the document records currently in the repo and the set of
+ * rkeys the build wants to keep, return the rkeys that should be deleted.
+ * Exported for unit testing.
+ */
+export function computeOrphanRkeys(existingRecords, keepRkeys) {
+  const keep = keepRkeys instanceof Set ? keepRkeys : new Set(keepRkeys);
+  const orphans = [];
+  for (const rec of existingRecords) {
+    const rkey = rec.uri.split("/").pop();
+    if (rkey && !keep.has(rkey)) orphans.push(rkey);
+  }
+  return orphans;
+}
+
+async function readManifest() {
+  let raw;
+  try {
+    raw = await readFile(MANIFEST_URL, "utf8");
+  } catch {
+    fail("dist/standard-site.json not found — run `pnpm build` first");
+  }
+  const manifest = JSON.parse(raw);
+
+  // Guard against drift between the static verification file and the records.
+  const wellKnown = (await readFile(WELL_KNOWN_URL, "utf8")).trim();
+  if (wellKnown !== manifest.publication.uri) {
+    fail(
+      `.well-known/site.standard.publication (${wellKnown}) does not match the ` +
+        `publication record AT-URI (${manifest.publication.uri})`,
+    );
+  }
+  return manifest;
+}
+
+async function main() {
+  if (!PASSWORD) {
+    fail(
+      "BSKY_APP_PASSWORD is required (create an app password at https://bsky.app/settings/app-passwords)",
+    );
+  }
+
+  const manifest = await readManifest();
+
+  // Resolve identity -> PDS, then open an app-password session.
+  const { did } = await xrpcGet(
+    "https://public.api.bsky.app",
+    "com.atproto.identity.resolveHandle",
+    { handle: HANDLE },
+  );
+  const pds = await resolvePds(did);
+  const session = await xrpcPost(pds, "com.atproto.server.createSession", {
+    identifier: HANDLE,
+    password: PASSWORD,
+  });
+  console.log(`✓ authenticated as ${HANDLE} (${session.did}) on ${pds}`);
+
+  // The records embed a hardcoded DID (their AT-URIs). If BSKY_HANDLE was
+  // overridden to a different account, we would otherwise write the blog's
+  // records into the wrong repo. Refuse unless the authenticated identity owns
+  // the DID the records are addressed to.
+  const recordDid = manifest.publication.uri.split("/")[2];
+  if (session.did !== recordDid) {
+    fail(
+      `authenticated DID (${session.did}) does not match the DID in the ` +
+        `records (${recordDid}); refusing to publish to the wrong repo`,
+    );
+  }
+
+  const records = [
+    {
+      collection: manifest.publication.record.$type,
+      rkey: manifest.publication.rkey,
+      record: manifest.publication.record,
+      uri: manifest.publication.uri,
+    },
+    ...manifest.documents.map((doc) => ({
+      collection: doc.record.$type,
+      rkey: doc.rkey,
+      record: doc.record,
+      uri: doc.uri,
+    })),
+  ];
+
+  for (const { collection, rkey, record, uri } of records) {
+    // validate:false — the PDS does not host the site.standard.* lexicons, so
+    // schema validation would reject otherwise-valid records.
+    await xrpcPost(
+      pds,
+      "com.atproto.repo.putRecord",
+      { repo: session.did, collection, rkey, record, validate: false },
+      session.accessJwt,
+    );
+    console.log(`✓ put ${uri}`);
+  }
+
+  // Prune document records with no matching post. Runs only after every current
+  // record has been upserted above, so a failure mid-run never strands the blog
+  // without its live records.
+  let deleted = 0;
+  if (manifest.documents.length === 0) {
+    // A broken or empty build must never be able to wipe the whole collection.
+    console.warn(
+      "⚠ manifest has no documents — skipping orphan cleanup to avoid deleting every record",
+    );
+  } else {
+    const collection = manifest.documents[0].record.$type;
+    const keep = new Set(manifest.documents.map((doc) => doc.rkey));
+    const existing = await listAllRecords(pds, session.did, collection);
+    const orphans = computeOrphanRkeys(existing, keep);
+    for (const rkey of orphans) {
+      await xrpcPost(
+        pds,
+        "com.atproto.repo.deleteRecord",
+        { repo: session.did, collection, rkey },
+        session.accessJwt,
+      );
+      console.log(`✓ deleted orphan at://${session.did}/${collection}/${rkey}`);
+      deleted += 1;
+    }
+    if (deleted === 0) console.log("✓ no orphaned document records to prune");
+  }
+
+  console.log(
+    `\nDone — published 1 publication + ${manifest.documents.length} ` +
+      `document(s)${deleted > 0 ? `, pruned ${deleted} orphan(s)` : ""}.`,
+  );
+}
+
+// Only run when invoked directly (`node publish-standard-site.mjs`), not when
+// imported by a test that exercises the pure helpers above.
+if (argv[1] && fileURLToPath(import.meta.url) === argv[1]) {
+  main().catch((err) => fail(err instanceof Error ? err.message : String(err)));
+}

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -3,9 +3,13 @@ import { ClientRouter } from 'astro:transitions';
 import SeoHead from "../components/general/SeoHead.astro"
 import Header from "../components/general/Header.astro"
 import Footer from "../components/general/Footer.astro"
+import { publicationUri, documentUri } from "../lib/standard-site"
 import '../css/style.css';
 
 const { postData } = Astro.props;
+// standard.site (https://standard.site): link every page to the publication and
+// each post to its document record so AT Protocol readers can resolve them.
+const postSlug = postData?.data?.slug;
 ---
 <!doctype html>
 <html lang="en">
@@ -44,6 +48,8 @@ const { postData } = Astro.props;
     <meta name="view-transition" content="same-origin" />
     <meta name="follow.it-verification-code" content="ztErNAHHpKlvFYurVBEd"/>
     <link rel="alternate" type="application/rss+xml" title="Read at BYK's" href={new URL("rss.xml", Astro.site)} />
+    <link rel="site.standard.publication" href={publicationUri()} />
+    {postSlug && <link rel="site.standard.document" href={documentUri(postSlug)} />}
     <SeoHead postData={postData} />
     <link rel="preload" href="/fonts/inter-v12-latin_latin-ext-regular.woff2" as="font" crossorigin>
     <link rel="preload" href="/fonts/inter-v12-latin_latin-ext-700.woff2" as="font" crossorigin>

--- a/src/lib/standard-site.ts
+++ b/src/lib/standard-site.ts
@@ -1,0 +1,206 @@
+/**
+ * Standard.site (https://standard.site) AT Protocol integration for byk.im.
+ *
+ * The blog is modeled as a single `site.standard.publication` record plus one
+ * `site.standard.document` record per post, stored in the `@byk.im` Bluesky
+ * account's PDS.
+ *
+ * We use DETERMINISTIC record keys — the publication is `self`, each document
+ * uses its post slug — so the AT-URIs are predictable. That lets the on-page
+ * verification (`<link rel="site.standard.document">` and the `.well-known`
+ * endpoint) be generated at build time without first reading back what the PDS
+ * assigned, and makes publishing idempotent: `putRecord` upserts in place
+ * rather than creating duplicates on re-runs.
+ *
+ * The records themselves are materialized by `scripts/publish-standard-site.mjs`,
+ * which reads the build manifest emitted by `src/pages/standard-site.json.ts`.
+ *
+ * NOTE: this module is intentionally framework-free (no `astro:*` imports) so
+ * it can be imported from layouts/endpoints and from plain Node scripts alike.
+ *
+ * If you change `PUBLICATION_DID` or `PUBLICATION_RKEY`, also update the static
+ * verification file at `public/.well-known/site.standard.publication` (the
+ * publish script asserts the two stay in sync before writing any record).
+ */
+
+/** DID of the `@byk.im` Bluesky account (resolved from the handle). */
+export const PUBLICATION_DID = "did:plc:kl3s4yablm3fgnxfkn47uy5r";
+
+/** Record key of the singleton publication record. */
+export const PUBLICATION_RKEY = "self";
+
+/** Base URL combined with a document path to form its canonical URL. No trailing slash. */
+export const SITE_URL = "https://byk.im";
+
+export const PUBLICATION_NAME = "Read at BYK's";
+export const PUBLICATION_DESCRIPTION =
+  "Random ramblings of a software engineer. Mostly about software, sometimes about life.";
+
+const PUBLICATION_COLLECTION = "site.standard.publication";
+const DOCUMENT_COLLECTION = "site.standard.document";
+
+/** AT-URI of the publication record. */
+export function publicationUri(): string {
+  return `at://${PUBLICATION_DID}/${PUBLICATION_COLLECTION}/${PUBLICATION_RKEY}`;
+}
+
+/**
+ * AT Protocol record-key syntax: 1–512 chars from `[A-Za-z0-9._~:-]`, and never
+ * `.` or `..`. See https://atproto.com/specs/record-key.
+ */
+const RECORD_KEY_RE = /^[A-Za-z0-9._~:-]{1,512}$/;
+
+/**
+ * Documents are keyed by their post slug for stable, idempotent AT-URIs.
+ *
+ * A slug with `/` for nested directories, unicode letters, or other stray
+ * characters is illegal in a record key. Rather than silently mangle the slug
+ * (which would desync the on-page `<link>` from the published record), fail the
+ * build loudly so a problematic slug is a deliberate decision, not a broken
+ * AT-URI / rejected PDS write.
+ */
+export function documentRkey(slug: string): string {
+  if (!slug || slug === "." || slug === ".." || !RECORD_KEY_RE.test(slug)) {
+    throw new Error(
+      `Blog slug "${slug}" is not a valid AT Protocol record key ` +
+        "(allowed: 1–512 chars of A–Z a–z 0–9 . _ ~ : - ; not '.' or '..'). " +
+        "Fix the post's frontmatter `slug` or add an explicit mapping in standard-site.ts.",
+    );
+  }
+  return slug;
+}
+
+/** AT-URI of a document record. */
+export function documentUri(slug: string): string {
+  return `at://${PUBLICATION_DID}/${DOCUMENT_COLLECTION}/${documentRkey(slug)}`;
+}
+
+/** Site-relative path for a post; combined with `SITE_URL` to form its URL. */
+export function documentPath(slug: string): string {
+  return `/posts/${slug}/`;
+}
+
+interface RgbColor {
+  $type: "site.standard.theme.color#rgb";
+  r: number;
+  g: number;
+  b: number;
+}
+
+function rgb(r: number, g: number, b: number): RgbColor {
+  return { $type: "site.standard.theme.color#rgb", r, g, b };
+}
+
+// byk.im palette (see src/css/style.css): white surface, deep-blue ink, pink
+// accent. Mirrors the rendered blog so reader apps keep the site's identity.
+const BASIC_THEME = {
+  $type: "site.standard.theme.basic" as const,
+  background: rgb(255, 255, 255), // --color-pacamara-white #ffffff
+  foreground: rgb(0, 48, 73), // --color-pacamara-primary #003049
+  accent: rgb(255, 180, 180), // --color-pacamara-accent #ffb4b4
+  accentForeground: rgb(0, 14, 20), // --color-pacamara-dark #000e14
+};
+
+export interface PublicationRecord {
+  $type: "site.standard.publication";
+  url: string;
+  name: string;
+  description: string;
+  basicTheme: typeof BASIC_THEME;
+  preferences: { showInDiscover: boolean };
+}
+
+export function buildPublicationRecord(): PublicationRecord {
+  return {
+    $type: PUBLICATION_COLLECTION,
+    url: SITE_URL,
+    name: PUBLICATION_NAME,
+    description: PUBLICATION_DESCRIPTION,
+    basicTheme: BASIC_THEME,
+    preferences: { showInDiscover: true },
+  };
+}
+
+/**
+ * Upper bound on a document record's `textContent`, in UTF-8 bytes.
+ *
+ * `textContent` is supplementary — the canonical post lives on the site at the
+ * record's `path` — so it is safe to truncate. The AT Protocol repository spec
+ * delegates the hard maximum record size to PDS implementations rather than
+ * fixing a number (see https://atproto.com/specs/repository, "Security
+ * Considerations"), so we impose a conservative self-bound: generous enough
+ * that no realistic post is trimmed, while keeping records and firehose events
+ * from growing without limit.
+ */
+export const MAX_TEXT_CONTENT_BYTES = 64 * 1024;
+
+const TRUNCATION_MARKER = "\n[truncated]";
+
+/**
+ * Clamp `text` to at most `maxBytes` UTF-8 bytes for use as a record's
+ * `textContent`. Never splits a multi-byte code point, prefers a whitespace
+ * boundary so it does not cut mid-word, and appends a marker so consumers can
+ * tell the text was trimmed. The result is always <= `maxBytes` bytes.
+ */
+export function capTextContent(
+  text: string,
+  maxBytes = MAX_TEXT_CONTENT_BYTES,
+): string {
+  const encoder = new TextEncoder();
+  const encoded = encoder.encode(text);
+  if (encoded.length <= maxBytes) return text;
+
+  const budget = Math.max(
+    0,
+    maxBytes - encoder.encode(TRUNCATION_MARKER).length,
+  );
+  // Decode the byte-prefix; a trailing partial code point becomes U+FFFD, which
+  // we drop so the output is always valid UTF-8 within budget.
+  let head = new TextDecoder("utf-8").decode(encoded.subarray(0, budget));
+  if (head.endsWith("\uFFFD")) head = head.slice(0, -1);
+  // Back off to a whitespace boundary when one is close, so we cut between words
+  // rather than mid-word; keep the hard cut if the tail has no late whitespace
+  // (e.g. one enormous token) so we never collapse to near-empty.
+  const atBoundary = head.replace(/\S+$/, "").trimEnd();
+  if (atBoundary.length >= head.length * 0.8) head = atBoundary;
+  return `${head.trimEnd()}${TRUNCATION_MARKER}`;
+}
+
+export interface DocumentInput {
+  slug: string;
+  title: string;
+  description?: string;
+  /** ISO 8601 timestamp. */
+  publishedAt: string;
+  /** ISO 8601 timestamp. */
+  updatedAt?: string;
+  tags?: string[];
+  textContent?: string;
+}
+
+export interface DocumentRecord {
+  $type: "site.standard.document";
+  site: string;
+  path: string;
+  title: string;
+  publishedAt: string;
+  description?: string;
+  updatedAt?: string;
+  tags?: string[];
+  textContent?: string;
+}
+
+export function buildDocumentRecord(input: DocumentInput): DocumentRecord {
+  const record: DocumentRecord = {
+    $type: DOCUMENT_COLLECTION,
+    site: publicationUri(),
+    path: documentPath(input.slug),
+    title: input.title,
+    publishedAt: input.publishedAt,
+  };
+  if (input.description) record.description = input.description;
+  if (input.updatedAt) record.updatedAt = input.updatedAt;
+  if (input.tags && input.tags.length > 0) record.tags = input.tags;
+  if (input.textContent) record.textContent = capTextContent(input.textContent);
+  return record;
+}

--- a/src/pages/standard-site.json.ts
+++ b/src/pages/standard-site.json.ts
@@ -1,0 +1,94 @@
+import mdxRenderer from "@astrojs/mdx/server.js";
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { getCollection, render } from "astro:content";
+import {
+  buildDocumentRecord,
+  buildPublicationRecord,
+  documentRkey,
+  documentUri,
+  PUBLICATION_RKEY,
+  publicationUri,
+} from "../lib/standard-site";
+
+// Build-time export of the standard.site records for the blog. The publish
+// script (scripts/publish-standard-site.mjs) reads this from dist/ and writes
+// the records to the PDS, so the bytes that ship to AT Protocol are exactly
+// what the site renders here — no second source of truth.
+
+// Reduce rendered post HTML to plaintext for the document record's
+// `textContent` (the lexicon wants plaintext, no markup). Best-effort for our
+// authored posts, not a general HTML-to-text engine.
+function htmlToText(html: string): string {
+  return (
+    html
+      .replace(/<script[\s\S]*?<\/script>/gi, " ")
+      .replace(/<style[\s\S]*?<\/style>/gi, " ")
+      .replace(/<br\s*\/?>/gi, "\n")
+      .replace(
+        /<\/(p|div|h[1-6]|li|blockquote|pre|tr|figure|section|header)>/gi,
+        "\n",
+      )
+      .replace(/<[^>]+>/g, " ")
+      .replace(/&nbsp;/g, " ")
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;|&apos;|&#x27;/gi, "'")
+      // `&amp;` last so an escaped entity like `&amp;lt;` decodes to `&lt;`, not `<`.
+      .replace(/&amp;/g, "&")
+      .replace(/[ \t]+/g, " ")
+      .replace(/ *\n */g, "\n")
+      .replace(/\n{3,}/g, "\n\n")
+      .trim()
+  );
+}
+
+export async function GET() {
+  // Container API renders a post's compiled `Content` to an HTML string outside
+  // the page pipeline (same approach as rss.xml.js). The MDX renderer handles
+  // the `.mdx` posts this blog is authored in.
+  const container = await AstroContainer.create();
+  container.addServerRenderer({ renderer: mdxRenderer });
+
+  const posts = (await getCollection("posts")).sort(
+    (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
+  );
+
+  const documents = await Promise.all(
+    posts.map(async (post) => {
+      // Posts URL off the frontmatter `slug` (see src/pages/posts/[slug].astro),
+      // not the file id, so the record rkey must too. A missing slug would
+      // otherwise stringify to "undefined" and silently mint a bogus rkey.
+      const slug = post.data.slug;
+      if (!slug) {
+        throw new Error(
+          `Post "${post.id}" has no frontmatter \`slug\`; cannot derive a stable standard.site record key.`,
+        );
+      }
+      const { Content } = await render(post);
+      const html = await container.renderToString(Content);
+      const record = buildDocumentRecord({
+        slug,
+        title: post.data.title,
+        description: post.data.intro,
+        publishedAt: post.data.pubDate.toISOString(),
+        tags: post.data.tag ? [post.data.tag] : undefined,
+        textContent: htmlToText(html),
+      });
+      return { rkey: documentRkey(slug), uri: documentUri(slug), record };
+    }),
+  );
+
+  const manifest = {
+    publication: {
+      rkey: PUBLICATION_RKEY,
+      uri: publicationUri(),
+      record: buildPublicationRecord(),
+    },
+    documents,
+  };
+
+  return new Response(`${JSON.stringify(manifest, null, 2)}\n`, {
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}


### PR DESCRIPTION
Mirrors the [standard.site](https://standard.site) integration shipped for withlore.ai, adapted to this blog. Models the blog as a single \`site.standard.publication\` plus one \`site.standard.document\` per post in the \`@byk.im\` PDS, so AT Protocol readers can discover and resolve posts.

## Identity (resolved & verified)
- handle \`byk.im\` · DID \`did:plc:kl3s4yablm3fgnxfkn47uy5r\` (verified via DNS TXT \`_atproto.byk.im\`) · PDS \`https://meadow.us-east.host.bsky.network\`
- \`BSKY_APP_PASSWORD\` repo secret already provisioned (app password for the \`byk.im\` account).

## What's here
- **\`src/lib/standard-site.ts\`** — deterministic AT-URIs (publication \`self\`, documents keyed by frontmatter \`slug\`), record-key charset guard (fails the build on an illegal slug), 64 KiB \`textContent\` cap (byte-accurate, word-boundary backoff), brand theme from the pacamara palette, and record builders.
- **\`src/pages/standard-site.json.ts\`** — build manifest emitted to \`dist/standard-site.json\`; renders each post to plaintext via the Container API (same approach as \`rss.xml.js\`). Sorted newest-first; throws on a missing slug.
- **\`scripts/publish-standard-site.mjs\`** — zero-dependency XRPC publisher: app-password session → **DID cross-check** (refuses to write to the wrong repo) → idempotent \`putRecord\` upserts → **orphan prune** for renamed/deleted posts (paginated with a dual stop so it can never spin forever; skips entirely when the manifest has no documents so a broken build can't wipe the collection).
- **\`public/.well-known/site.standard.publication\`** — static AT-URI verification file.
- **\`src/layouts/Base.astro\`** — \`rel="site.standard.publication"\` on every page, \`rel="site.standard.document"\` on posts.
- **\`.github/workflows/deploy.yml\`** — publishes records from the built \`./dist\` after the Pages build, gated on the \`BSKY_APP_PASSWORD\` secret with \`continue-on-error\` (a transient PDS outage never fails the deploy).

## Keys
- publication: \`at://did:plc:kl3s4yablm3fgnxfkn47uy5r/site.standard.publication/self\`
- documents: \`at://did:plc:kl3s4yablm3fgnxfkn47uy5r/site.standard.document/{slug}\`

## Verification (local build)
- \`pnpm build\` succeeds; \`dist/standard-site.json\` has 1 publication + 11 documents, single DID throughout, max \`textContent\` 12,155 B (well under the 64 KiB cap).
- \`dist/.well-known/site.standard.publication\` byte-matches the publication AT-URI.
- Built post HTML carries **both** \`rel=publication\` and \`rel=document\`; homepage and listing carry publication only.
- \`computeOrphanRkeys\` unit-sanity passes (renamed→pruned, array/Set forms, empty→[]); import-safety guard confirmed (\`main()\` does not run on import).

The real PDS publish runs in CI on merge to \`master\` (idempotent upsert), exactly like the withlore.ai site.

## Notes
- No test runner is configured in this repo, so the (already unit/mutation-tested upstream) logic is ported verbatim and verified via the build. Happy to add a harness if wanted.
- Per-post cover images / publication icon (blob uploads) are deferred as a possible follow-up.