### PR TITLE
feat: add publication icon and post cover images to standard.site records

### DIFF
--- a/scripts/publish-standard-site.mjs
+++ b/scripts/publish-standard-site.mjs
@@ -31,6 +31,15 @@ const WELL_KNOWN_URL = new URL(
   "../public/.well-known/site.standard.publication",
   import.meta.url,
 );
+const DIST_URL = new URL("../dist/", import.meta.url);
+
+// Hard ceiling for image blobs (icon / coverImage). The lexicons declare
+// maxSize: 1000000 for both site.standard.publication#icon and
+// site.standard.document#coverImage; mirror it here (kept in sync with
+// MAX_BLOB_BYTES in src/lib/standard-site.ts). Anything larger is skipped, not
+// uploaded, so an oversized asset degrades to a record without a cover rather
+// than failing the write.
+const MAX_BLOB_BYTES = 1_000_000;
 
 function fail(message) {
   console.error(`✗ ${message}`);
@@ -58,6 +67,47 @@ async function xrpcPost(baseUrl, nsid, body, token) {
   });
   if (!res.ok) fail(`${nsid} -> ${res.status}: ${await res.text()}`);
   return res.json();
+}
+
+/**
+ * Upload raw image bytes as an AT Protocol blob and return the resulting blob
+ * ref (the `{$type:"blob", ref, mimeType, size}` object embedded into records).
+ */
+async function uploadBlob(pds, bytes, mimeType, token) {
+  const res = await fetch(new URL("/xrpc/com.atproto.repo.uploadBlob", pds), {
+    method: "POST",
+    headers: { "content-type": mimeType, authorization: `Bearer ${token}` },
+    body: bytes,
+  });
+  if (!res.ok)
+    fail(`com.atproto.repo.uploadBlob -> ${res.status}: ${await res.text()}`);
+  return (await res.json()).blob;
+}
+
+/**
+ * Read a manifest blob source from the build output and upload it, returning the
+ * blob ref. Best-effort: a missing or oversized file logs a warning and returns
+ * null so the record is still published — just without the image — rather than
+ * failing the whole run. (The bytes ship to AT Protocol exactly as built; the
+ * size cap mirrors the lexicon's 1 MB maxSize.)
+ */
+async function resolveBlob(source, token, pds) {
+  let bytes;
+  try {
+    bytes = await readFile(new URL(source.path, DIST_URL));
+  } catch {
+    console.warn(
+      `⚠ blob ${source.path} not found in dist/ — publishing record without it`,
+    );
+    return null;
+  }
+  if (bytes.length > MAX_BLOB_BYTES) {
+    console.warn(
+      `⚠ blob ${source.path} is ${bytes.length} bytes (> ${MAX_BLOB_BYTES} cap) — publishing record without it`,
+    );
+    return null;
+  }
+  return uploadBlob(pds, bytes, source.mimeType, token);
 }
 
 async function resolvePds(did) {
@@ -162,16 +212,38 @@ async function main() {
       rkey: manifest.publication.rkey,
       record: manifest.publication.record,
       uri: manifest.publication.uri,
+      // Publication icon: blob field is `icon`.
+      blobField: "icon",
+      blobSource: manifest.publication.icon,
     },
     ...manifest.documents.map((doc) => ({
       collection: doc.record.$type,
       rkey: doc.rkey,
       record: doc.record,
       uri: doc.uri,
+      // Document cover image: blob field is `coverImage`.
+      blobField: "coverImage",
+      blobSource: doc.coverImage,
     })),
   ];
 
-  for (const { collection, rkey, record, uri } of records) {
+  for (const {
+    collection,
+    rkey,
+    record,
+    uri,
+    blobField,
+    blobSource,
+  } of records) {
+    // Upload the image blob (if any) and attach its ref before writing the
+    // record, so the record and its blob land in a single putRecord. Blobs are
+    // content-addressed, so unchanged bytes yield the same ref and the upsert
+    // stays a no-op on re-runs; resolveBlob returns null (record published
+    // without the image) on a missing/oversized file rather than failing.
+    if (blobSource) {
+      const blob = await resolveBlob(blobSource, session.accessJwt, pds);
+      if (blob) record[blobField] = blob;
+    }
     // validate:false — the PDS does not host the site.standard.* lexicons, so
     // schema validation would reject otherwise-valid records.
     await xrpcPost(
@@ -180,7 +252,7 @@ async function main() {
       { repo: session.did, collection, rkey, record, validate: false },
       session.accessJwt,
     );
-    console.log(`✓ put ${uri}`);
+    console.log(`✓ put ${uri}${record[blobField] ? " (+image)" : ""}`);
   }
 
   // Prune document records with no matching post. Runs only after every current

--- a/src/lib/standard-site.ts
+++ b/src/lib/standard-site.ts
@@ -80,6 +80,45 @@ export function documentPath(slug: string): string {
   return `/posts/${slug}/`;
 }
 
+/**
+ * Maximum size, in bytes, of an image blob (`icon` / `coverImage`).
+ *
+ * The `site.standard.publication#icon` and `site.standard.document#coverImage`
+ * fields both declare `maxSize: 1000000` in the lexicon. We generate small
+ * web-optimized variants well under this, but the publish script enforces it as
+ * a hard ceiling and skips (rather than uploads) anything larger so an oversized
+ * asset degrades to a record without a cover instead of a rejected write.
+ */
+export const MAX_BLOB_BYTES = 1_000_000;
+
+/**
+ * A blob to upload at publish time, described as a path relative to the build
+ * output (`dist/`) plus its MIME type. Blobs cannot live in the static manifest
+ * — an AT Protocol blob ref only exists once bytes are uploaded to the PDS — so
+ * the manifest points at the built file and `scripts/publish-standard-site.mjs`
+ * uploads it and attaches the returned ref to the record.
+ */
+export interface BlobSource {
+  /** Path to the image file relative to the build output directory (`dist/`). */
+  path: string;
+  /** MIME type to upload the blob as (e.g. `image/webp`). */
+  mimeType: string;
+}
+
+/**
+ * Reduce an asset URL produced by Astro's image pipeline to a path relative to
+ * the build output (`dist/`).
+ *
+ * With `build.assetsPrefix` set (this site uses `https://byk.im/`), `getImage()`
+ * returns an absolute URL like `https://byk.im/_astro/cover.hash.webp`; without
+ * it the URL is root-relative like `/_astro/cover.hash.webp`. Parsing against
+ * `SITE_URL` and taking the pathname normalizes both to `_astro/cover.hash.webp`,
+ * which is exactly where the file sits under `dist/`.
+ */
+export function assetUrlToDistPath(assetUrl: string): string {
+  return new URL(assetUrl, SITE_URL).pathname.replace(/^\/+/, "");
+}
+
 interface RgbColor {
   $type: "site.standard.theme.color#rgb";
   r: number;

--- a/src/pages/standard-site.json.ts
+++ b/src/pages/standard-site.json.ts
@@ -1,7 +1,11 @@
 import mdxRenderer from "@astrojs/mdx/server.js";
+import { getImage } from "astro:assets";
 import { experimental_AstroContainer as AstroContainer } from "astro/container";
 import { getCollection, render } from "astro:content";
+import bykAvatar from "../assets/authors/byk.png";
 import {
+  assetUrlToDistPath,
+  type BlobSource,
   buildDocumentRecord,
   buildPublicationRecord,
   documentRkey,
@@ -9,6 +13,36 @@ import {
   PUBLICATION_RKEY,
   publicationUri,
 } from "../lib/standard-site";
+
+// The publication icon and per-document cover images are uploaded to the PDS as
+// AT Protocol blobs by the publish script. Blob refs can't be precomputed into
+// this static manifest (a ref only exists once the bytes are uploaded), so we
+// emit small, web-optimized variants here via `getImage()` and record their
+// build-output paths; the publish script reads those files, uploads them, and
+// attaches the returned ref. Variants are well under the lexicon's 1 MB cap
+// (and the post originals — e.g. a 5 MB PNG — would blow it, so we never ship
+// those raw).
+
+/** Square publication icon (lexicon wants square, >=256px). */
+async function buildIconSource(): Promise<BlobSource> {
+  const icon = await getImage({
+    src: bykAvatar,
+    width: 512,
+    height: 512,
+    fit: "cover",
+    format: "webp",
+  });
+  return { path: assetUrlToDistPath(icon.src), mimeType: "image/webp" };
+}
+
+/** Web-optimized cover image for a post, or undefined when it has no image. */
+async function buildCoverSource(
+  image: ImageMetadata | undefined,
+): Promise<BlobSource | undefined> {
+  if (!image) return undefined;
+  const cover = await getImage({ src: image, width: 1200, format: "webp" });
+  return { path: assetUrlToDistPath(cover.src), mimeType: "image/webp" };
+}
 
 // Build-time export of the standard.site records for the blog. The publish
 // script (scripts/publish-standard-site.mjs) reads this from dist/ and writes
@@ -75,7 +109,13 @@ export async function GET() {
         tags: post.data.tag ? [post.data.tag] : undefined,
         textContent: htmlToText(html),
       });
-      return { rkey: documentRkey(slug), uri: documentUri(slug), record };
+      const coverImage = await buildCoverSource(post.data.image);
+      return {
+        rkey: documentRkey(slug),
+        uri: documentUri(slug),
+        record,
+        ...(coverImage ? { coverImage } : {}),
+      };
     }),
   );
 
@@ -84,6 +124,7 @@ export async function GET() {
       rkey: PUBLICATION_RKEY,
       uri: publicationUri(),
       record: buildPublicationRecord(),
+      icon: await buildIconSource(),
     },
     documents,
   };


### PR DESCRIPTION
## What

Populates the two image fields the standard.site lexicons define but byk.im's records weren't using yet:

- **`site.standard.publication#icon`** — the author avatar resized to a square **512×512 webp** (the lexicon wants a square image ≥256px).
- **`site.standard.document#coverImage`** — each post's frontmatter `image` as a **1200px-wide webp**. Posts without an `image` (just `life-lessons-from-a-rotary-encoder` today) get no cover.

Reader apps / indexers that consume these records can now show the blog's identity and per-post thumbnails.

## How

A blob ref only exists once bytes are uploaded to the PDS, so it can't be precomputed into the static `dist/standard-site.json` manifest. Instead:

1. `standard-site.json.ts` emits small web-optimized webp variants via `getImage()` and records their **dist-relative paths** + mime type in the manifest (`publication.icon`, `documents[].coverImage`).
2. `publish-standard-site.mjs` reads each file, uploads it via `com.atproto.repo.uploadBlob`, and attaches the returned blob ref to the record **before** `putRecord` — so the record and its blob land in one write.

Content-addressed CIDs keep re-runs idempotent: unchanged bytes → same ref → upsert stays a no-op.

## Size cap

Both fields declare `maxSize: 1000000` (1 MB). The generated variants are tiny (icon 20 KB; largest cover `roots` 110 KB; `adaptation`'s 5 MB PNG original optimizes to 99 KB), so nothing is ever trimmed in practice. The publish script still enforces the cap defensively — **best-effort**: a missing or oversized file logs a warning and the record is published *without* the image rather than failing the whole run (same philosophy as the existing `textContent` cap).

## Verification

- `pnpm build` succeeds; manifest carries `icon` + 10 `coverImage` paths; every referenced file exists in `dist/` and is < 1 MB.
- Sanity-checked `assetUrlToDistPath` (absolute-with-assetsPrefix and root-relative forms) and the size-guard skip logic; `computeOrphanRkeys` regression intact; publish script parses clean.
- Post-merge: confirm `docs`/deploy publishes, then `getRecord` the publication + a document to confirm the `icon`/`coverImage` blobs resolved.